### PR TITLE
PN-7736 Synchronize skin detection between JSP and JS

### DIFF
--- a/src/loader/js/meta.js
+++ b/src/loader/js/meta.js
@@ -52,7 +52,16 @@
                                        //////////////////////
                                        // Temporary fix for PN-7736 - skin detection issue
                                        // between JSP and JS
-                                       defaultSkin: (document.body.className.indexOf('wf2-skin-nxt') !== -1) ? 'nxt' : (document.body.className.indexOf('wf2-skin-nx') !== -1) ? 'nx' : Y.UA.touchEnabled ? 'nxt' : 'nx',
+                                       defaultSkin: (function () {
+                                          var bodyClass = document.body.className;
+                                          if (/wf2\-skin\-nx\b/.test(bodyClass)) {
+                                            return 'nx';
+                                          } else if (/wf2\-skin\-nxt\b/.test(bodyClass)) {
+                                            return 'nxt';
+                                          } else {
+                                            return Y.UA.touchEnabled ? 'nxt' : 'nx';
+                                          }
+                                       })(),
                                        // defaultSkin: Y.UA.touchEnabled ? 'nxt' : 'nx',
                                        //////////////////////
                                        //  END WF2 CHANGE  //

--- a/src/loader/js/meta.js
+++ b/src/loader/js/meta.js
@@ -50,7 +50,10 @@
                                        //////////////////////
                                        // BEGIN WF2 CHANGE //
                                        //////////////////////
-                                       defaultSkin: Y.UA.touchEnabled ? 'nxt' : 'nx',
+                                       // Temporary fix for PN-7736 - skin detection issue
+                                       // between JSP and JS
+                                       defaultSkin: (document.body.className.indexOf('wf2-skin-nxt') !== -1) ? 'nxt' : (document.body.className.indexOf('wf2-skin-nx') !== -1) ? 'nx' : Y.UA.touchEnabled ? 'nxt' : 'nx',
+                                       // defaultSkin: Y.UA.touchEnabled ? 'nxt' : 'nx',
                                        //////////////////////
                                        //  END WF2 CHANGE  //
                                        //////////////////////

--- a/src/loader/js/meta.js
+++ b/src/loader/js/meta.js
@@ -56,7 +56,7 @@
                                           var body = document.body,
                                           bodyClass = body ? body.className : '',
                                           hasNx = false,
-                                          hasNxt =false;
+                                          hasNxt = false;
 
                                           if (/wf2\-skin\-nx\b/.test(bodyClass)) {
                                             hasNx = true;

--- a/src/loader/js/meta.js
+++ b/src/loader/js/meta.js
@@ -51,15 +51,26 @@
                                        // BEGIN WF2 CHANGE //
                                        //////////////////////
                                        // Temporary fix for PN-7736 - skin detection issue
-                                       // between JSP and JS
+                                       // between JSP and JS.
                                        defaultSkin: (function () {
                                           var body = document.body,
-                                          bodyClass = body ? body.className : '';
+                                          bodyClass = body ? body.className : '',
+                                          hasNx = false,
+                                          hasNxt =false;
+
                                           if (/wf2\-skin\-nx\b/.test(bodyClass)) {
-                                            return 'nx';
-                                          } else if (/wf2\-skin\-nxt\b/.test(bodyClass)) {
-                                            return 'nxt';
-                                          } else {
+                                            hasNx = true;
+                                          }
+                                          if (/wf2\-skin\-nxt\b/.test(bodyClass)) {
+                                            hasNxt = true;
+                                          }
+                                          if ((hasNx && !hasNxt) || (!hasNx && hasNxt)) {
+                                            // Only one wf2-skin-xxx class, it comes from JSP.
+                                            return hasNx? 'nx':'nxt';
+                                          }
+                                          if ((hasNx && hasNxt) || (!hasNx && !hasNxt)) {
+                                            // Either 2 classes are there or none. JSP didn't do
+                                            // anything here, we can safely detect the right one.
                                             return Y.UA.touchEnabled ? 'nxt' : 'nx';
                                           }
                                        })(),

--- a/src/loader/js/meta.js
+++ b/src/loader/js/meta.js
@@ -53,7 +53,8 @@
                                        // Temporary fix for PN-7736 - skin detection issue
                                        // between JSP and JS
                                        defaultSkin: (function () {
-                                          var bodyClass = document.body.className;
+                                          var body = document.body,
+                                          bodyClass = body ? body.className : '';
                                           if (/wf2\-skin\-nx\b/.test(bodyClass)) {
                                             return 'nx';
                                           } else if (/wf2\-skin\-nxt\b/.test(bodyClass)) {


### PR DESCRIPTION
Checking classes at the body level:
- if only one of these 2 classes are on the body (wf2-skin-nx and wf2-skin-nxt), it means it's intentional or set by the JSP page tag: load the corresponding skin.
- if none of these 2 classes are present or both are present, then use the touch detection mechanism to load the right skin. (in that case, we know that the class was NOT set by the JSP tag).
