### PR TITLE
PN-6992: Appliying refactor of the WidgetModal mixin. The internal modal...

### DIFF
--- a/src/widget-modality/js/Widget-Modality.js
+++ b/src/widget-modality/js/Widget-Modality.js
@@ -172,10 +172,17 @@ var WIDGET       = 'widget',
     };
 
     /**
-     * A stack of Y.Widget objects representing the current hierarchy of modal widgets presently displayed on the screen
+     * A (global) stack of Y.Widget objects representing the current hierarchy of modal widgets presently displayed on the screen
+     * PN-6992 Commented out the original STACK instantiation line, and switched out WidgetModal.STACK for YUI.Env.WidgetModal.STACK
+     * to make the WidgetModal bean counting cross-sandbox aware. The fact that modality only ever uses one overlay suggests this 
+     * class should have implemented the bean counting mechanism to be cross-sandbox aware. aalbino 2014-10-17 12:25pm
      * @property STACK
      */
-    WidgetModal.STACK = [];
+    // WidgetModal.STACK = []; 
+    if (!YUI.Env.WidgetModal) {
+        YUI.namespace('Env.WidgetModal');
+        YUI.Env.WidgetModal.STACK = [];
+    }
 
 
     WidgetModal.prototype = {

--- a/src/widget-modality/js/Widget-Modality.js
+++ b/src/widget-modality/js/Widget-Modality.js
@@ -318,7 +318,7 @@ var WIDGET       = 'widget',
          * @param {boolean} Whether the widget is visible or not
          */
         _uiSetHostVisibleModal : function (visible) {
-            var stack    = WidgetModal.STACK,
+            var stack    = YUI.Env.WidgetModal.STACK,
                 maskNode = this.get('maskNode'),
                 isModal  = this.get('modal'),
                 topModal, index;
@@ -402,7 +402,7 @@ var WIDGET       = 'widget',
          */
         _attachUIHandlesModal : function () {
 
-            if (this._uiHandlesModal || WidgetModal.STACK[0] !== this) {
+            if (this._uiHandlesModal || YUI.Env.WidgetModal.STACK[0] !== this) {
                 // Quit early if we have ui handles, or if we not at the top
                 // of the global stack.
                 return;
@@ -497,7 +497,7 @@ var WIDGET       = 'widget',
          * @public
          */
         isNested: function() {
-            var length = WidgetModal.STACK.length,
+            var length = YUI.Env.WidgetModal.STACK.length,
             retval = (length > 1) ? true : false;
             return retval;
         },

--- a/src/widget-modality/tests/manual/double-modal-different-sandboxes.html
+++ b/src/widget-modality/tests/manual/double-modal-different-sandboxes.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Double Modal Test Page</title>
+</head>
+<body class="yui3-skin-sam">
+
+    <h1>Lorem Ipsum</h1>
+    <p>Closing one modal while displaying another should not lose the modal overlay until all modal widgets are closed.</p>
+
+<script src="../../../../build/yui/yui.js"></script>
+<script>
+YUI({filter: 'raw'}).use('panel', function (Y) {
+
+    var panel1 = new Y.Panel({
+        headerContent: 'Dialog 1',
+        bodyContent  : 'Hello',
+        modal        : true,
+        centered     : true,
+        visible      : false,
+
+        hideOn: [
+            { eventName: 'click' }
+        ],
+
+        buttons: [
+            {
+                value  : 'Close',
+                section: Y.WidgetStdMod.FOOTER,
+                action : function(e) {
+                    console.log('stack', YUI.Env.WidgetModal.STACK);
+                    console.log('Dialog 1, is nested?', this.isNested());
+                    this.hide();
+                }
+            }
+        ]
+    });
+
+    panel1.render().show();
+
+});
+
+
+YUI().use('panel', function (Y) {
+
+    var panel2 = new Y.Panel({
+        headerContent: 'Session Timeout',
+        bodyContent  : 'Your session timeout message.',
+        modal        : true,
+        centered     : false,
+        visible      : false,
+
+        hideOn: [
+            { eventName: 'click' }
+        ],
+
+        buttons: [
+            {
+                value  : 'Ok',
+                section: Y.WidgetStdMod.FOOTER,
+                action : function(e) {
+                    console.log('stack', YUI.Env.WidgetModal.STACK);
+                    console.log('Dialog2, is nested?', this.isNested());
+                    this.hide();
+                }
+            }
+        ]
+    });
+
+    panel2.render().show();
+
+});
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
PN-6992: The YUI3 library only allows for a single modal overlay...but the internal bean counting mechanism didn't account for this. This refactor has made the internal STACK variable a 'global' variable, so that the internal bean counting mechanism keeps a valid count irregardless of the sandbox.
