### PR TITLE
Fix button template to have an end tag instead of a self enclosing tag

### DIFF
--- a/src/button/js/core.js
+++ b/src/button/js/core.js
@@ -25,9 +25,9 @@ ButtonCore.prototype = {
      *
      * @property TEMPLATE
      * @type {String}
-     * @default <button/>
+     * @default <button></button>
      */
-    TEMPLATE: '<button/>',
+    TEMPLATE: '<button></button>',
 
     /**
      *


### PR DESCRIPTION
Fixed the button template to have an end tag instead of a self enclosing tag.
