### PR TITLE
Resolving animation and style errors

### DIFF
--- a/src/anim/js/anim-easing.js
+++ b/src/anim/js/anim-easing.js
@@ -48,6 +48,9 @@ var Easing = {
      * @return {Number} The computed value for the current animation frame
      */
     easeNone: function (t, b, c, d) {
+        if (!d) {
+            return c + b;
+        }
         return c*t/d + b;
     },
 
@@ -61,6 +64,9 @@ var Easing = {
      * @return {Number} The computed value for the current animation frame
      */
     easeIn: function (t, b, c, d) {
+        if (!d) {
+            return c + b;
+        }
         return c*(t/=d)*t + b;
     },
 
@@ -74,6 +80,9 @@ var Easing = {
      * @return {Number} The computed value for the current animation frame
      */
     easeOut: function (t, b, c, d) {
+        if (!d) {
+            return c + b;
+        }
         return -c *(t/=d)*(t-2) + b;
     },
 
@@ -87,6 +96,10 @@ var Easing = {
      * @return {Number} The computed value for the current animation frame
      */
     easeBoth: function (t, b, c, d) {
+        // value return increases from beginning until half the duration has passed, then decreases to 0
+        if (!d) {
+            return c + b;
+        }
         if ((t /= d/2) < 1) {
             return c/2*t*t + b;
         }
@@ -104,6 +117,9 @@ var Easing = {
      * @return {Number} The computed value for the current animation frame
      */
     easeInStrong: function (t, b, c, d) {
+        if (!d) {
+            return c + b;
+        }
         return c*(t/=d)*t*t*t + b;
     },
 
@@ -117,6 +133,9 @@ var Easing = {
      * @return {Number} The computed value for the current animation frame
      */
     easeOutStrong: function (t, b, c, d) {
+        if (!d) {
+            return c + b;
+        }
         return -c * ((t=t/d-1)*t*t*t - 1) + b;
     },
 
@@ -130,6 +149,9 @@ var Easing = {
      * @return {Number} The computed value for the current animation frame
      */
     easeBothStrong: function (t, b, c, d) {
+        if (!d) {
+            return c + b;
+        }
         if ((t /= d/2) < 1) {
             return c/2*t*t*t*t + b;
         }
@@ -151,6 +173,9 @@ var Easing = {
 
     elasticIn: function (t, b, c, d, a, p) {
         var s;
+        if (!d) {
+            return b+c;
+        }
         if (t === 0) {
             return b;
         }
@@ -185,6 +210,9 @@ var Easing = {
      */
     elasticOut: function (t, b, c, d, a, p) {
         var s;
+        if (!d) {
+            return b+c;
+        }
         if (t === 0) {
             return b;
         }
@@ -219,6 +247,9 @@ var Easing = {
      */
     elasticBoth: function (t, b, c, d, a, p) {
         var s;
+        if (!d) {
+            return b+c;
+        }
         if (t === 0) {
             return b;
         }
@@ -259,6 +290,9 @@ var Easing = {
      * @return {Number} The computed value for the current animation frame
      */
     backIn: function (t, b, c, d, s) {
+        if (!d) {
+            return c + b;
+        }
         if (s === undefined) {
             s = 1.70158;
         }
@@ -279,6 +313,9 @@ var Easing = {
      * @return {Number} The computed value for the current animation frame
      */
     backOut: function (t, b, c, d, s) {
+        if (!d) {
+            return c + b;
+        }
         if (typeof s === 'undefined') {
             s = 1.70158;
         }
@@ -297,6 +334,9 @@ var Easing = {
      * @return {Number} The computed value for the current animation frame
      */
     backBoth: function (t, b, c, d, s) {
+        if (!d) {
+            return c + b;
+        }
         if (typeof s === 'undefined') {
             s = 1.70158;
         }
@@ -317,6 +357,9 @@ var Easing = {
      * @return {Number} The computed value for the current animation frame
      */
     bounceIn: function (t, b, c, d) {
+        if (!d) {
+            return 0; // c - (c+b) + b
+        }
         return c - Y.Easing.bounceOut(d-t, 0, c, d) + b;
     },
 
@@ -330,6 +373,9 @@ var Easing = {
      * @return {Number} The computed value for the current animation frame
      */
     bounceOut: function (t, b, c, d) {
+        if (!d) {
+            return c + b;
+        }
         if ((t/=d) < (1/2.75)) {
                 return c*(7.5625*t*t) + b;
         } else if (t < (2/2.75)) {
@@ -350,6 +396,9 @@ var Easing = {
      * @return {Number} The computed value for the current animation frame
      */
     bounceBoth: function (t, b, c, d) {
+        if (!d) {
+            return c + b;
+        }
         if (t < d/2) {
             return Y.Easing.bounceIn(t * 2, 0, c, d) * 0.5 + b;
         }

--- a/src/anim/js/anim-easing.js
+++ b/src/anim/js/anim-easing.js
@@ -96,7 +96,6 @@ var Easing = {
      * @return {Number} The computed value for the current animation frame
      */
     easeBoth: function (t, b, c, d) {
-        // value return increases from beginning until half the duration has passed, then decreases to 0
         if (!d) {
             return c + b;
         }
@@ -358,7 +357,7 @@ var Easing = {
      */
     bounceIn: function (t, b, c, d) {
         if (!d) {
-            return 0; // c - (c+b) + b
+            return 0;
         }
         return c - Y.Easing.bounceOut(d-t, 0, c, d) + b;
     },

--- a/src/anim/js/anim.js
+++ b/src/anim/js/anim.js
@@ -81,6 +81,9 @@
     Y.Anim.DEFAULT_UNIT = 'px';
 
     Y.Anim.DEFAULT_EASING = function (t, b, c, d) {
+        if (!d) {
+            c + b;
+        }
         return c * t / d + b; // linear easing
     };
 

--- a/src/dom/js/dom-style.js
+++ b/src/dom/js/dom-style.js
@@ -117,10 +117,12 @@ Y.mix(Y_DOM, {
      * @param {Object} hash An object literal of property:value pairs. 
      */
     setStyles: function(node, hash) {
-        var style = node.style;
-        Y.each(hash, function(v, n) {
-            Y_DOM.setStyle(node, n, v, style);
-        }, Y_DOM);
+        if (node) {
+            var style = node.style;
+            Y.each(hash, function(v, n) {
+                Y_DOM.setStyle(node, n, v, style);
+            }, Y_DOM);
+        }
     },
 
     /**


### PR DESCRIPTION
The easing functions divide the time cycle by the duration to determine the frame. If the duration is zero, this throws an error rather than returning the last frame. This PR adds an early return for cases when duration is 0.

The second change in this PR adds a conditional check for the value of the node parameter in the setStyles method to resolve a null reference error.
